### PR TITLE
Remove namespace alias

### DIFF
--- a/quickstart-templates/application-serviceprincipal-create-client-resource/main.bicep
+++ b/quickstart-templates/application-serviceprincipal-create-client-resource/main.bicep
@@ -1,4 +1,4 @@
-import 'microsoftGraph@1.0.0' as graph
+import 'microsoftGraph@1.0.0'
 
 @description('Id of the application role to add to the resource app')
 param appRoleId string

--- a/quickstart-templates/resource-application-access-grant-to-client-application/main.bicep
+++ b/quickstart-templates/resource-application-access-grant-to-client-application/main.bicep
@@ -1,4 +1,4 @@
-import 'microsoftGraph@1.0.0' as graph
+import 'microsoftGraph@1.0.0'
 
 @description('Id of the application role to add to the resource app')
 param appRoleId string

--- a/quickstart-templates/security-group-assign-azure-role/main.bicep
+++ b/quickstart-templates/security-group-assign-azure-role/main.bicep
@@ -1,4 +1,4 @@
-import 'microsoftGraph@1.0.0' as graph
+import 'microsoftGraph@1.0.0'
 
 @description('Specifies the Reader role definition ID used in the role assignment.')
 param readerRoleDefinitionID string = 'acdd72a7-3385-48ef-bd42-f606fba81ae7'

--- a/quickstart-templates/security-group-create-with-owners-and-members/main.bicep
+++ b/quickstart-templates/security-group-create-with-owners-and-members/main.bicep
@@ -1,4 +1,4 @@
-import 'microsoftGraph@1.0.0' as graph
+import 'microsoftGraph@1.0.0'
 
 @description('location of the resource group')
 param location string = resourceGroup().location


### PR DESCRIPTION
Removing the alias `as graph` for the Microsoft Graph namespace