### PR TITLE
Update quickstart examples to use uniquename for apps and groups

### DIFF
--- a/quickstart-templates/application-serviceprincipal-create-client-resource/main.bicep
+++ b/quickstart-templates/application-serviceprincipal-create-client-resource/main.bicep
@@ -8,7 +8,7 @@ param appRoleId string
 param certKey string
 
 resource resourceApp 'Microsoft.Graph/applications@beta' = {
-  name: 'ExampleResourceApp'
+  uniqueName: 'ExampleResourceApp'
   displayName: 'Example Resource Application'
   appRoles: [
     {
@@ -27,7 +27,7 @@ resource resourceSp 'Microsoft.Graph/servicePrincipals@beta' = {
 }
 
 resource clientApp 'Microsoft.Graph/applications@beta' = {
-  name: 'ExampleClientApp'
+  uniqueName: 'ExampleClientApp'
   displayName: 'Example Client Application'
   keyCredentials: [
     {

--- a/quickstart-templates/resource-application-access-grant-to-client-application/main.bicep
+++ b/quickstart-templates/resource-application-access-grant-to-client-application/main.bicep
@@ -4,7 +4,7 @@ provider 'microsoftGraph@1.0.0'
 param appRoleId string
 
 resource resourceApp 'Microsoft.Graph/applications@beta' existing = {
-  name: 'ExampleResourceApp'
+  uniqueName: 'ExampleResourceApp'
 }
 
 resource resourceSp 'Microsoft.Graph/servicePrincipals@beta' existing = {
@@ -12,7 +12,7 @@ resource resourceSp 'Microsoft.Graph/servicePrincipals@beta' existing = {
 }
 
 resource clientApp 'Microsoft.Graph/applications@beta' existing = {
-  name: 'ExampleClientApp'
+  uniqueName: 'ExampleClientApp'
 }
 
 resource clientSp 'Microsoft.Graph/servicePrincipals@beta' existing = {

--- a/quickstart-templates/security-group-assign-azure-role/main.bicep
+++ b/quickstart-templates/security-group-assign-azure-role/main.bicep
@@ -4,7 +4,7 @@ provider 'microsoftGraph@1.0.0'
 param readerRoleDefinitionID string = 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
 
 resource group 'Microsoft.Graph/groups@beta' existing = {
-  name: 'ExampleGroup'
+  uniqueName: 'ExampleGroup'
 }
 
 var roleAssignmentName = guid('ExampleGroup', readerRoleDefinitionID, resourceGroup().id)

--- a/quickstart-templates/security-group-create-with-owners-and-members/main.bicep
+++ b/quickstart-templates/security-group-create-with-owners-and-members/main.bicep
@@ -4,7 +4,7 @@ provider 'microsoftGraph@1.0.0'
 param location string = resourceGroup().location
 
 resource resourceApp 'Microsoft.Graph/applications@beta' existing = {
-  name: 'ExampleResourceApp'
+  uniqueName: 'ExampleResourceApp'
 }
 
 resource resourceSp 'Microsoft.Graph/servicePrincipals@beta' existing = {
@@ -17,7 +17,7 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
 }
 
 resource group 'Microsoft.Graph/groups@beta' = {
-  name: 'ExampleGroup'
+  uniqueName: 'ExampleGroup'
   displayName: 'Example Group'
   mailEnabled: false
   mailNickname: 'exampleGroup'


### PR DESCRIPTION
Update applications and groups to use `uniqueName` in quickstart examples. Change will be effective when latest Bicep compiler is released
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-bicep-types/pull/70)