### PR TITLE
Update quickstart examples for fic v1.0 and feature flag removal

### DIFF
--- a/quickstart-templates/application-serviceprincipal-create-client-resource/bicepconfig.json
+++ b/quickstart-templates/application-serviceprincipal-create-client-resource/bicepconfig.json
@@ -1,6 +1,5 @@
 {
     "experimentalFeaturesEnabled": {
-        "extensibility": true,
-        "microsoftGraphPreview": true
+        "extensibility": true
     }
 }

--- a/quickstart-templates/create-client-app-sp-with-kv-cert/bicepconfig.json
+++ b/quickstart-templates/create-client-app-sp-with-kv-cert/bicepconfig.json
@@ -1,6 +1,5 @@
 {
     "experimentalFeaturesEnabled": {
-        "extensibility": true,
-        "microsoftGraphPreview": true
+        "extensibility": true
     }
 }

--- a/quickstart-templates/create-fic-for-github-actions/bicepconfig.json
+++ b/quickstart-templates/create-fic-for-github-actions/bicepconfig.json
@@ -1,6 +1,5 @@
 {
     "experimentalFeaturesEnabled": {
-        "extensibility": true,
-        "microsoftGraphPreview": true
+        "extensibility": true
     }
 }

--- a/quickstart-templates/create-fic-for-github-actions/main.bicep
+++ b/quickstart-templates/create-fic-for-github-actions/main.bicep
@@ -13,7 +13,7 @@ resource githubActionsApp 'Microsoft.Graph/applications@v1.0' = {
   uniqueName: 'githubActionsApp'
   displayName: 'Github Actions App'
 
-  resource githubFic 'federatedIdentityCredentials@beta' = {
+  resource githubFic 'federatedIdentityCredentials' = {
     name: '${githubActionsApp.uniqueName}/githubFic'
     audiences: [microsoftEntraAudience]
     description: 'FIC for Github Actions to access Entra protected resources'

--- a/quickstart-templates/resource-application-access-grant-to-client-application/bicepconfig.json
+++ b/quickstart-templates/resource-application-access-grant-to-client-application/bicepconfig.json
@@ -1,6 +1,5 @@
 {
     "experimentalFeaturesEnabled": {
-        "extensibility": true,
-        "microsoftGraphPreview": true
+        "extensibility": true
     }
 }

--- a/quickstart-templates/security-group-assign-azure-role/bicepconfig.json
+++ b/quickstart-templates/security-group-assign-azure-role/bicepconfig.json
@@ -1,6 +1,5 @@
 {
     "experimentalFeaturesEnabled": {
-        "extensibility": true,
-        "microsoftGraphPreview": true
+        "extensibility": true
     }
 }

--- a/quickstart-templates/security-group-create-with-owners-and-members/bicepconfig.json
+++ b/quickstart-templates/security-group-create-with-owners-and-members/bicepconfig.json
@@ -1,6 +1,5 @@
 {
     "experimentalFeaturesEnabled": {
-        "extensibility": true,
-        "microsoftGraphPreview": true
+        "extensibility": true
     }
 }


### PR DESCRIPTION
The latest Bicep release will include `applications/federatedIdentityCredentials@v1.0` and remove the `microsoftGraphPreview` feature flag. Update the quickstart examples accordingly
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-bicep-types/pull/94)