### PR TITLE
Graph Bicep types updates and removal

### DIFF
--- a/generated/microsoftgraph/microsoft.graph/beta/types.json
+++ b/generated/microsoftgraph/microsoft.graph/beta/types.json
@@ -1732,7 +1732,7 @@
         "type": {
           "$ref": "#/22"
         },
-        "flags": 0,
+        "flags": 2,
         "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications"
       },
       "appRoleAssignmentRequired": {

--- a/generated/microsoftgraph/microsoft.graph/beta/types.md
+++ b/generated/microsoftgraph/microsoft.graph/beta/types.md
@@ -139,7 +139,7 @@
 * **appDisplayName**: string: The display name exposed by the associated application.
 * **appId**: string (Required): The unique identifier for the associated application (its appId property). Alternate key
 * **applicationTemplateId**: string (ReadOnly): Unique identifier of the applicationTemplate. Read-only. null if the app wasn't created from an application template.
-* **appOwnerOrganizationId**: string {minLength: 36, maxLength: 36, pattern: "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"}: Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications
+* **appOwnerOrganizationId**: string {minLength: 36, maxLength: 36, pattern: "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"} (ReadOnly): Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications
 * **appRoleAssignmentRequired**: bool: Specifies whether users or other service principals need to be granted an app role assignment for this service principal before users can sign in or apps can get tokens. The default value is false. Not nullable
 * **appRoles**: [MicrosoftGraphAppRole](#microsoftgraphapprole)[]: The roles exposed by the application, which this service principal represents. For more information, see the appRoles property definition on the application entity. Not nullable.
 * **deletedDateTime**: string (ReadOnly): Date and time when this object was deleted. Always null when the object hasn't been deleted.

--- a/generated/microsoftgraph/microsoft.graph/v1.0/types.json
+++ b/generated/microsoftgraph/microsoft.graph/v1.0/types.json
@@ -526,12 +526,6 @@
         "flags": 0,
         "description": "Notes relevant for the management of the application."
       },
-      "oauth2RequirePostResponse": {
-        "type": {
-          "$ref": "#/5"
-        },
-        "flags": 0
-      },
       "optionalClaims": {
         "type": {
           "$ref": "#/38"
@@ -1647,7 +1641,7 @@
         "type": {
           "$ref": "#/18"
         },
-        "flags": 0,
+        "flags": 2,
         "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications"
       },
       "appRoleAssignmentRequired": {

--- a/generated/microsoftgraph/microsoft.graph/v1.0/types.md
+++ b/generated/microsoftgraph/microsoft.graph/v1.0/types.md
@@ -25,7 +25,6 @@
 * **keyCredentials**: [MicrosoftGraphKeyCredential](#microsoftgraphkeycredential)[]: The collection of key credentials associated with the application. Not nullable
 * **logo**: string: The main logo for the application. Not nullable.
 * **notes**: string: Notes relevant for the management of the application.
-* **oauth2RequirePostResponse**: bool
 * **optionalClaims**: [MicrosoftGraphOptionalClaims](#microsoftgraphoptionalclaims): Application developers can configure optional claims in their Microsoft Entra applications to specify the claims that are sent to their application by the Microsoft security token service. For more information, see How to: Provide optional claims to your app.
 * **parentalControlSettings**: [MicrosoftGraphParentalControlSettings](#microsoftgraphparentalcontrolsettings): Specifies parental control settings for an application.
 * **passwordCredentials**: [MicrosoftGraphPasswordCredential](#microsoftgraphpasswordcredential)[]: The collection of password credentials associated with the application. Not nullable.
@@ -134,7 +133,7 @@
 * **appDisplayName**: string: The display name exposed by the associated application.
 * **appId**: string (Required): The unique identifier for the associated application (its appId property). Alternate key
 * **applicationTemplateId**: string (ReadOnly): Unique identifier of the applicationTemplate. Read-only. null if the service principal wasn't created from an application template.
-* **appOwnerOrganizationId**: string {minLength: 36, maxLength: 36, pattern: "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"}: Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications
+* **appOwnerOrganizationId**: string {minLength: 36, maxLength: 36, pattern: "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"} (ReadOnly): Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications
 * **appRoleAssignmentRequired**: bool: Specifies whether users or other service principals need to be granted an app role assignment for this service principal before users can sign in or apps can get tokens. The default value is false. Not nullable
 * **appRoles**: [MicrosoftGraphAppRole](#microsoftgraphapprole)[]: The roles exposed by the application that's linked to this service principal. For more information, see the appRoles property definition on the application entity. Not nullable.
 * **customSecurityAttributes**: any: An open complex type that holds the value of a custom security attribute that is assigned to a directory object. Nullable. Filter value is case sensitive.

--- a/src/swagger-generation/config-beta.yml
+++ b/src/swagger-generation/config-beta.yml
@@ -51,6 +51,7 @@ EntityTypes:
     Upsertable: true
     IgnoredProperties:
       - onPremisesPublishing
+      - oauth2RequirePostResponse
     RequiredOnWrite:
       - displayName
       - uniqueName
@@ -70,6 +71,7 @@ EntityTypes:
       - appId
     ReadOnly:
       - applicationTemplateId
+      - appOwnerOrganizationId
       - signInAudience
   - Name: microsoft.graph.federatedIdentityCredential
     RootUri: /applications/federatedIdentityCredentials

--- a/src/swagger-generation/config-v1.0.yml
+++ b/src/swagger-generation/config-v1.0.yml
@@ -42,6 +42,8 @@ EntityTypes:
   - Name: microsoft.graph.application
     RootUri: /applications
     Upsertable: true
+    IgnoredProperties:
+      - oauth2RequirePostResponse
     RequiredOnWrite:
       - displayName
       - uniqueName
@@ -58,6 +60,7 @@ EntityTypes:
       - appId
     ReadOnly:
       - applicationTemplateId
+      - appOwnerOrganizationId
       - resourceSpecificApplicationPermissions
       - signInAudience
   - Name: microsoft.graph.federatedIdentityCredential

--- a/src/swagger-generation/output/microsoftgraph-beta.json
+++ b/src/swagger-generation/output/microsoftgraph-beta.json
@@ -464,7 +464,8 @@
             "appOwnerOrganizationId": {
               "type": "string",
               "format": "uuid",
-              "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications"
+              "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications",
+              "readOnly": true
             },
             "appRoleAssignmentRequired": {
               "type": "boolean",

--- a/src/swagger-generation/output/microsoftgraph-v1.0.json
+++ b/src/swagger-generation/output/microsoftgraph-v1.0.json
@@ -295,10 +295,6 @@
               "type": "string",
               "description": "Notes relevant for the management of the application."
             },
-            "oauth2RequirePostResponse": {
-              "type": "boolean",
-              "description": ""
-            },
             "optionalClaims": {
               "$ref": "#/definitions/microsoft.graph.optionalClaims",
               "description": "Application developers can configure optional claims in their Microsoft Entra applications to specify the claims that are sent to their application by the Microsoft security token service. For more information, see How to: Provide optional claims to your app."
@@ -433,7 +429,8 @@
             "appOwnerOrganizationId": {
               "type": "string",
               "format": "uuid",
-              "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications"
+              "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications",
+              "readOnly": true
             },
             "appRoleAssignmentRequired": {
               "type": "boolean",

--- a/swagger/specification/microsoftgraph/resource-manager/microsoftgraph/preview/beta/microsoftgraph-beta.json
+++ b/swagger/specification/microsoftgraph/resource-manager/microsoftgraph/preview/beta/microsoftgraph-beta.json
@@ -464,7 +464,8 @@
             "appOwnerOrganizationId": {
               "type": "string",
               "format": "uuid",
-              "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications"
+              "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications",
+              "readOnly": true
             },
             "appRoleAssignmentRequired": {
               "type": "boolean",

--- a/swagger/specification/microsoftgraph/resource-manager/microsoftgraph/preview/v1.0/microsoftgraph-v1.0.json
+++ b/swagger/specification/microsoftgraph/resource-manager/microsoftgraph/preview/v1.0/microsoftgraph-v1.0.json
@@ -295,10 +295,6 @@
               "type": "string",
               "description": "Notes relevant for the management of the application."
             },
-            "oauth2RequirePostResponse": {
-              "type": "boolean",
-              "description": ""
-            },
             "optionalClaims": {
               "$ref": "#/definitions/microsoft.graph.optionalClaims",
               "description": "Application developers can configure optional claims in their Microsoft Entra applications to specify the claims that are sent to their application by the Microsoft security token service. For more information, see How to: Provide optional claims to your app."
@@ -433,7 +429,8 @@
             "appOwnerOrganizationId": {
               "type": "string",
               "format": "uuid",
-              "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications"
+              "description": "Contains the tenant ID where the application is registered. This is applicable only to service principals backed by applications",
+              "readOnly": true
             },
             "appRoleAssignmentRequired": {
               "type": "boolean",


### PR DESCRIPTION
- `oauth2RequirePostResponse` is removed from `applications` #155 
- `appOwnerOrganizationId` is marked as read-only in `servicePrincipals`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-bicep-types/pull/158)