### PR TITLE
Create initial workload identity federation

### DIFF
--- a/quickstart-templates/workload-identity-creates-workload-identities/README.md
+++ b/quickstart-templates/workload-identity-creates-workload-identities/README.md
@@ -1,0 +1,20 @@
+# Create Workload Identity Federation That Can Create Other Workload Identity Federations
+
+## The Idea
+
+Restrict and limit the need to use high privileges to create resources.
+
+## Objective
+
+A high-privilege user creates an initial workload identity federation token between Azure and a certain GitHub repository. The workload in this repository is then allowed to access Microsoft Entra to create further workload identity federation tokens and assign them to other repositories.
+
+## Benefits
+
+- **Enhanced Security:** Restricting high-privilege usage reduces the attack surface and potential for unauthorized access.
+- **Scalability:** Facilitates the growth of projects by enabling the creation of new identity federations as needed.
+- **Efficient Management:** Streamlines the process of managing resource access across multiple projects and teams.
+
+
+```sh
+az deployment tenant create --template-file main.bicep
+```

--- a/quickstart-templates/workload-identity-creates-workload-identities/bicepconfig.json
+++ b/quickstart-templates/workload-identity-creates-workload-identities/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+    "experimentalFeaturesEnabled": {
+        "extensibility": true
+    }
+}

--- a/quickstart-templates/workload-identity-creates-workload-identities/main.bicep
+++ b/quickstart-templates/workload-identity-creates-workload-identities/main.bicep
@@ -1,0 +1,54 @@
+targetScope = 'tenant'
+extension microsoftGraph
+
+resource azureRootManagementGroup 'Microsoft.Management/managementGroups@2023-04-01' existing = {
+  scope: tenant()
+  name: '<guid>'
+}
+
+@description('The owner of the organization that it assigned to a workload identity that is used by GitHub Actions to deploy further resources.')
+var gitHubOwner = '<MyOrganization>'
+
+@description('The GitHub repository that is assigned to a workload identity that is used by GitHub Actions to deploy further resources.')
+var gitHubRepo = '<MyOrganizationRootProject>'
+
+@description('Subject of the GitHub Actions workflow\'s federated identity credentials (FIC) that is checked before issuing an Entra ID access token to access Azure resources. GitHub Actions subject examples can be found in https://docs.github.com/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims.')
+var gitHubActionsFederatedIdentitySubject = 'repo:${gitHubOwner}/${gitHubRepo}:ref:refs/heads/main'
+
+
+var applicationIdentityRegistrationDisplayName = 'GitHub Actions Identity Application Deployer'
+var applicationIdentityRegistrationName = 'root-appident-deployer'
+var githubOIDCProvider = 'https://token.actions.githubusercontent.com'
+var microsoftEntraAudience = 'api://AzureADTokenExchange'
+resource identityGithubActionsApplication 'Microsoft.Graph/applications@v1.0' = {
+uniqueName: applicationIdentityRegistrationName
+displayName: applicationIdentityRegistrationDisplayName
+
+resource githubFederatedIdentityCredential 'federatedIdentityCredentials@v1.0' = {
+  name: '${identityGithubActionsApplication.uniqueName}/githubFederatedIdentityCredential'
+  audiences: [microsoftEntraAudience]
+  description: 'Identity for application to deploy the root identity infrastructure.'
+  issuer: githubOIDCProvider
+  subject: gitHubActionsFederatedIdentitySubject
+  }
+}
+
+resource gitHubIdentityActionsServicePrincipal 'Microsoft.Graph/servicePrincipals@v1.0' = {
+displayName: applicationIdentityRegistrationDisplayName
+appId: identityGithubActionsApplication.appId
+}
+
+resource msGraphSP 'Microsoft.Graph/servicePrincipals@v1.0' existing = {
+  appId: '00000003-0000-0000-c000-000000000000'
+}
+
+// search for appRole by app role permission friendly name
+param appRoleName string = 'Application.ReadWrite.OwnedBy'
+var graphAppRoles = msGraphSP.appRoles
+var appRoleDetail = filter(graphAppRoles, graphAppRoles => graphAppRoles.value == appRoleName)
+
+resource symbolicname 'Microsoft.Graph/appRoleAssignedTo@v1.0' = {
+  appRoleId: appRoleDetail[0].id
+  principalId: gitHubIdentityActionsServicePrincipal.id // Client SP being granted permission to access the resource (API)
+  resourceId: msGraphSP.id // Resource here is Microsoft Graph
+}


### PR DESCRIPTION
- Establish an initial workload identity federation token between Azure and a specific GitHub repository using a high-privilege user.

- Enable workloads in the repository to access Microsoft Entra for creating additional workload identity federation tokens.

New created federated workload identity tokens can be assigned to other repositories, reducing the need for high-privilege access. This enhances security by limiting the usage of high-privilege credentials and providing scalable identity management.

Closes #154