### PR TITLE
Update appRoleAssignedTo metadata to support all principal types

### DIFF
--- a/src/swagger-generation/config-beta.yml
+++ b/src/swagger-generation/config-beta.yml
@@ -115,11 +115,9 @@ EntityTypes:
       - creationTimestamp
       - principalDisplayName
       - principalType
-    FilterProperty:
-      - resourceId
     CompositeKey:
       - appRoleId
-      - resourceId
+      - principalId
   - Name: microsoft.graph.appRole
     ReadOnly:
       - origin

--- a/src/swagger-generation/config-v1.0.yml
+++ b/src/swagger-generation/config-v1.0.yml
@@ -102,11 +102,9 @@ EntityTypes:
       - createdDateTime
       - principalDisplayName
       - principalType
-    FilterProperty:
-      - resourceId
     CompositeKey:
       - appRoleId
-      - resourceId
+      - principalId
   - Name: microsoft.graph.appRole
     ReadOnly:
       - origin

--- a/src/swagger-generation/output/metadata.json
+++ b/src/swagger-generation/output/metadata.json
@@ -104,12 +104,9 @@
       "isContainment": true,
       "containerEntitySet": "servicePrincipals",
       "keyProperty": "resourceId",
-      "temporaryFilterKeys": [
-        "resourceId"
-      ],
       "compositeKeyProperties": [
         "appRoleId",
-        "resourceId"
+        "principalId"
       ]
     },
     "v1.0": {
@@ -118,12 +115,9 @@
       "isContainment": true,
       "containerEntitySet": "servicePrincipals",
       "keyProperty": "resourceId",
-      "temporaryFilterKeys": [
-        "resourceId"
-      ],
       "compositeKeyProperties": [
         "appRoleId",
-        "resourceId"
+        "principalId"
       ]
     }
   }


### PR DESCRIPTION
- `/appRoleAssignedTo` doesn't use resourceId as filter
- Use principalId as part of the composite key
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-bicep-types/pull/164)