### PR TITLE
Update bicep-types and install dotnet 8 in pipeline

### DIFF
--- a/pipelines/common-templates/install-tools.yml
+++ b/pipelines/common-templates/install-tools.yml
@@ -12,6 +12,11 @@ steps:
     inputs:
       version: 6.x
 
+  - task: UseDotNet@2
+    displayName: "Use .NET 8"
+    inputs:
+      version: 8.x
+
   # Install the nuget tool.
   - task: NuGetToolInstaller@1
     displayName: "Use NuGet >=5.2.0"


### PR DESCRIPTION
Latest bicep-types uses dotnet 8 so update pipeline tools accordingly
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-bicep-types/pull/200)