### PR TITLE
Cleaning up templates by removing extensibility feature flag.

### DIFF
--- a/quickstart-templates-archive/create-fic-for-github-actions/bicepconfig.json
+++ b/quickstart-templates-archive/create-fic-for-github-actions/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview"

--- a/quickstart-templates-archive/security-group-assign-azure-role/bicepconfig.json
+++ b/quickstart-templates-archive/security-group-assign-azure-role/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview"

--- a/quickstart-templates/application-serviceprincipal-create-client-resource/bicepconfig.json
+++ b/quickstart-templates/application-serviceprincipal-create-client-resource/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"

--- a/quickstart-templates/apps-permissions-and-grants/bicepconfig.json
+++ b/quickstart-templates/apps-permissions-and-grants/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-  "experimentalFeaturesEnabled": {
-      "extensibility": true
-  },
   // specify an alias for the version of the v1.0 dynamic types package you want to use
   "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"

--- a/quickstart-templates/create-client-app-sp-with-kv-cert/bicepconfig.json
+++ b/quickstart-templates/create-client-app-sp-with-kv-cert/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"

--- a/quickstart-templates/create-fic-for-github-actions/bicepconfig.json
+++ b/quickstart-templates/create-fic-for-github-actions/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"

--- a/quickstart-templates/msi-as-a-fic-secretless/bicepconfig.json
+++ b/quickstart-templates/msi-as-a-fic-secretless/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"

--- a/quickstart-templates/resource-application-access-grant-to-client-application/bicepconfig.json
+++ b/quickstart-templates/resource-application-access-grant-to-client-application/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"

--- a/quickstart-templates/security-group-add-user-members/bicepconfig.json
+++ b/quickstart-templates/security-group-add-user-members/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"

--- a/quickstart-templates/security-group-assign-azure-role/bicepconfig.json
+++ b/quickstart-templates/security-group-assign-azure-role/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"

--- a/quickstart-templates/security-group-create-with-owners-and-members/bicepconfig.json
+++ b/quickstart-templates/security-group-create-with-owners-and-members/bicepconfig.json
@@ -1,7 +1,4 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     // specify an alias for the version of the v1.0 dynamic types package you want to use
     "extensions": {
       "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.2.0-preview"


### PR DESCRIPTION
This PR removes the experimental extensibility feature flag from the templates as it was removed in [PR #17094](https://github.com/Azure/bicep/pull/17094) in the Azure Bicep repository.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-bicep-types/pull/245)