### PR TITLE
Fix release type swagger generation script

### DIFF
--- a/scripts/UpdateGeneratedTypes.ps1
+++ b/scripts/UpdateGeneratedTypes.ps1
@@ -38,7 +38,7 @@ Write-Host "Autorest successfully built"
 Write-Host "Generating Swagger spec"
 npm ci --prefix $SwaggerGenerationPrefix
 npm audit fix
-npm run --prefix $SwaggerGenerationPrefix start "--" --output=C:\Git\msgraph-bicep-types\swagger\specification\microsoftgraph\resource-manager\microsoftgraph\preview
+npm run --prefix $SwaggerGenerationPrefix start "--" --output=C:\Git\msgraph-bicep-types\swagger\specification\microsoftgraph\resource-manager\microsoftgraph
 Write-Host "Swagger spec successfully generated"
 
 # Generate Bicep types

--- a/src/swagger-generation/src/index.ts
+++ b/src/swagger-generation/src/index.ts
@@ -45,7 +45,8 @@ async function parse(config: Config): Promise<[Metadata, Swagger]> {
 
 function writeSwaggerFile(swagger: Swagger, apiVersion: string, extensionVersion: string) {
   const swaggerJson: string = JSON.stringify(swagger, null, 2);
-  const fullOutputPath = `${outputPath}/${apiVersion}`;
+  const releaseType: string = getReleaseTypeFromExtensionVersion(extensionVersion);
+  const fullOutputPath = `${outputPath}/${releaseType}/${apiVersion}`;
 
   if (outputPath !== 'output') {
     if (!fs.existsSync(fullOutputPath)) {
@@ -77,11 +78,11 @@ function writeSwaggerReadMeFile(apiExtensionVersions: { [key in ApiVersion]: str
   let betaVersionsContent = '';
   let v1VersionsContent = '';
   for (const version of apiExtensionVersions[ApiVersion.Beta]) {
-    const releaseType = version.endsWith('preview') ? 'preview' : 'official';
+    const releaseType = getReleaseTypeFromExtensionVersion(version);
     betaVersionsContent += `\n  - microsoftgraph/${releaseType}/beta/${version}.json`;
   }
   for (const version of apiExtensionVersions[ApiVersion.V1_0]) {
-    const releaseType = version.endsWith('preview') ? 'preview' : 'official';
+    const releaseType = getReleaseTypeFromExtensionVersion(version);
     v1VersionsContent += `\n  - microsoftgraph/${releaseType}/v1.0/${version}.json`;
   }
   let readMeContent = `# MicrosoftGraph
@@ -128,6 +129,10 @@ input-file: ${v1VersionsContent}
     if (err) throw err;
     console.log(`The swagger readme file has been saved!`);
   });
+}
+
+function getReleaseTypeFromExtensionVersion(extensionVersion: string): 'preview' | 'official' {
+  return extensionVersion.endsWith('preview') ? 'preview' : 'official';
 }
 
 async function main() {


### PR DESCRIPTION
Fixing the output path and updated swagger generation script to correctly identify the release type based on the extension version.