### PR TITLE
ci: update ESRP code signing to v6

### DIFF
--- a/pipelines/common-templates/esrp/codesign-nuget.yml
+++ b/pipelines/common-templates/esrp/codesign-nuget.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 steps:
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+  - task: EsrpCodeSigning@6
     displayName: "ESRP CodeSigning Nuget Packages"
     inputs:
       ConnectedServiceName: "Federated DevX ESRP Managed Identity Connection"

--- a/pipelines/common-templates/esrp/codesign.yml
+++ b/pipelines/common-templates/esrp/codesign.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 steps:
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+  - task: EsrpCodeSigning@6
     displayName: "ESRP CodeSigning"
     inputs:
       ConnectedServiceName: "Federated DevX ESRP Managed Identity Connection"


### PR DESCRIPTION
Updates ESRP code signing tasks from v5 to v6. v5 runs on Node16 and is getting deprecated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-bicep-types/pull/310)